### PR TITLE
Adds base62 serialization support and ability to work in Python 2

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,23 @@
+[flake8]
+exclude = .idea, __pycache__, log, __init__.py, env
+max-line-length = 150
+max-complexity = 10
+filename = *.py
+format = default
+import-order-style = google
+inline-quotes = "
+ignore =
+	# E221 multiple spaces before operator
+	E221,
+	# whitespace before ':'
+	E203,
+	# whitespace before ')'
+	E202,
+	# multiple spaces after ','
+	E241,
+	# unexpected spaces around keyword / parameter equals
+	E251,
+	#comparison to True should be 'if cond is True:' or 'if cond (it's needed for SQLAlchemy)
+	E712
+
+

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,128 @@
-__pycache__
-*pyc
-dist
-*.egg-info
-*~
-*.DS_Store
+# Mac OS X system files
+.DS_Store
+
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+env/
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib64/
+parts/
+sdist/
+var/
+*.egg-info/
+.installed.cfg
+*.egg
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-delete-this-directory.txt
+pip-log.txt
+pip-selfcheck.json
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*,cover
+
+# Translations
+*.mo
+*.pot
+
+# Python and Django stuff:
+.python-version
+*.log
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# PyBuild
+.pybuild/
+
+# Node and NPM
+npm*.log*
+
+# IntelliJ IDEA and alike
+.idea/
+*.iml
+
+# Visual Studio and alike
+.vscode/
+bin/
+obj/
+bower_components/
+typings/
+node_modules/
+local/
+static/
+
+# Robots and Selenium artefacts
+integration/*.html
+integration/*.xml
+*/integration-tests/*.html
+*/integration-tests/*.xml
+
+
+# Miscellaneous
+log.txt
+tmp.txt
+mytest.sh
+chromedriver.exe
+aja_testit.bat
+/.vs/Balticsys/v14/.suo
+/web.config
+/web.debug.config
+/ptvs_virtualenv_proxy.py
+/obj/Debug/web.debug.config
+/obj/Debug/web.config
+/obj/Debug/visualstudio_py_util.py
+/obj/Debug/visualstudio_py_repl.py
+/obj/Debug/visualstudio_py_debugger.py
+/obj/Debug/deployment-updated-orig-prefix.txt
+/obj/Debug/Balticsys.pyproj.FileListAbsolute.txt
+/obj/Debug/attach_server.py
+/obj/Debug/__main__.py
+/obj/Debug/__init__.py
+/Balticsys.pyproj.user
+/.vs/config/applicationhost.config
+ui_tests/dev_runs/history/
+tests_all_dev.bat
+server/web.debug.config
+server/web.config
+server/.vs
+server/py3env
+server/python3
+sp-test-data/*
+# Vagrant
+.vagrant/
+infrastructure/dev/.vagrant
+infrastructure/alpha/archives
+infrastructure/empty_deb/debs/
+
+# ctags
+tags

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,46 @@
+ENV = env
+PYBIN = $(ENV)/scripts
+PYTHON = $(PYBIN)/python
+PIP = $(PYBIN)/pip
+PYTEST = $(PYTHON) -m pytest
+COVERAGE = $(PYTHON) -m coverage
+PYFLAKE8 = $(PYTHON) -m flake8
+TESTDIR = tests
+MODULE_NAME = ksuid
+DEV_CONFIG_FILE = ./conf/reqlog-dev.conf
+
+environ: clean requirements-dev.txt
+	virtualenv $(ENV)
+	$(PIP) install -r requirements-dev.txt
+
+.PHONY: help
+help:
+	@echo "make                 # create virtual env and setup dependencies"
+	@echo "make tests           # run tests"
+	@echo "make coverage        # run tests with coverage report"
+	@echo "make lint            # check linting"
+	@echo "make flake8          # alias for `make lint`"
+	@echo "make clean           # remove more or less everything created by make"
+
+.PHONY: tests
+tests:
+	$(PYTEST) $(TESTDIR) -vv
+
+.PHONY: coverage
+coverage:
+	$(PYTEST) $(TESTDIR) -vv --cov=$(MODULE_NAME)
+	$(COVERAGE) html
+
+.PHONY: lint
+lint:
+	$(PYFLAKE8)
+	
+.PHONY: flake8
+flake8:
+	$(PYFLAKE8)
+
+.PHONY: clean
+clean:
+	if exist $(ENV) rd $(ENV) /q /s
+	if exist reqlog.egg-info rd reqlog.egg-info /q /s
+	if exist .coverage del .coverage

--- a/Makefile
+++ b/Makefile
@@ -9,8 +9,17 @@ TESTDIR = tests
 MODULE_NAME = ksuid
 DEV_CONFIG_FILE = ./conf/reqlog-dev.conf
 
+SHELL=C:/Windows/System32/cmd.exe
+VIRTUALENV_APP_P27 = d:/Python27/python.exe -m virtualenv
+
+.PHONY: environ
 environ: clean requirements-dev.txt
 	virtualenv $(ENV)
+	$(PIP) install -r requirements-dev.txt
+	
+.PHONY: environ_p27
+environ_p27: clean requirements-dev.txt
+	$(VIRTUALENV_APP_P27) $(ENV)
 	$(PIP) install -r requirements-dev.txt
 
 .PHONY: help
@@ -44,3 +53,4 @@ clean:
 	if exist $(ENV) rd $(ENV) /q /s
 	if exist reqlog.egg-info rd reqlog.egg-info /q /s
 	if exist .coverage del .coverage
+	del /S *.pyc

--- a/README.md
+++ b/README.md
@@ -1,30 +1,31 @@
-<h1> KSUID </h1>
+# KSUID
 
-<h1> What is a ksuid? </h1>
+## What is a ksuid?
 
 A ksuid is a K sorted UID. In other words, a KSUID also stores a date component, so that ksuids can be approximately 
 sorted based on the time they were created. 
 
 
-<h1> Quick overview </h1>
+## Quick overview
 
 A ksuid is composed of two components: the date time, which is stored as the first four bytes of the uid, along with a randomly
 generated payload of 16, for a total of 20 bytes. 
 
-<h2> A few advantages </h2>
+## A few advantages
 
-1. The potential number of IDs available is greater than even that of UUID4 (which accepts 122 bits). KSUIDs are about 64 times larger than that. Coupled with the timestamp, the likelihood of getting 2 identical Ksuids is exceedingly low
+1. The potential number of IDs available is greater than even that of UUID4 (which accepts 122 bits). KSUIDs are about 64 times larger than that. Coupled with the timestamp, the likelihood of getting 2 identical Ksuids is exceedingly low;
+2. Enables sorting of UIDs in a sensible fashion, based on their timestamp;
+3. Supports Base62 encoding - can be serialized to Base62 and vice versa
 
-2. Enables sorting of UIDs in a sensible fashion, based on their timestamp.
 
-
-<h2> Installation </h2>
+## Installation
 
 The ksuid library can be installed via pip:
-<code>pip install ksuid</code>
 
-<h3> Note: currently only tested for Python 3.x </h3>
-<h2> Sample Usage: </h2>
+```pip install ksuid```
+
+** Note: currently only tested for Python 3.x </h3>**
+## Sample Usage:
 
 ```python
 >>> from ksuid import ksuid
@@ -41,8 +42,49 @@ The ksuid library can be installed via pip:
 >>> b'\x05\xcb\xd7\xd0\xc6\xcb\x98i\xeb\xa0}\xfa\x0f\x87\xf1\xf1\xe8\xa1\x83\x9e'
 ```
 
+## Base62 support
 
-<h1> Credit, where credit is due </h1>
+```python
+>>> import ksuid
+>>> uid = ksuid.ksuid()
+>>> print(uid)
+>>> '0607ac1e7955e3d6a5da87c8dae2e1825c8ddfc9'
+>>> v = uid.toBase62()
+>>> print(v)
+>>> 'rLIliIsDsLNj1b4tN1T3TZGC1B'
+```
+
+## Serialization to bytes support
+
+```python
+>>> import ksuid
+>>> uid = ksuid.ksuid()
+>>> print(uid)
+>>> '0607ac7351a48bb5e2f63b68094e465010496ff6'
+>>> v = uid.toBytes()
+>>> print(v)
+>>> b'\x06\x07\xacsQ\xa4\x8b\xb5\xe2\xf6;h\tNFP\x10Io\xf6'
+```
+
+## Developing
+
+First of all you need `make` utility for a little bit comfortable usage.
+
+You can execute `make help` to view all available commands.
+
+Please, run `make` to install virtual environment for testing and development.
+
+Supported commands:
+
+* `make` - create virtual env and setup dependencies;
+* `make tests` - run tests;
+* `make coverage` - run tests with coverage report;
+* `make lint` - check linting;
+* `make flake8` - alias for `make lint`
+* `make clean` - remove more or less everything created by make
+
+## Credit, where credit is due
 
 This library is largely inspired by the go version, found here:
 https://github.com/segmentio/ksuid
+

--- a/ksuid/__init__.py
+++ b/ksuid/__init__.py
@@ -3,4 +3,8 @@ import datetime
 import os
 import time
 
-from ksuid.ksuid import *
+try:
+    from ksuid.ksuid import *
+except ImportError:
+    from .ksuid import *
+

--- a/ksuid/base62.py
+++ b/ksuid/base62.py
@@ -5,7 +5,6 @@ base62
 
 Originated from http://blog.suminb.com/archives/558
 """
-
 __title__ = "base62"
 __author__ = "Sumin Byeon"
 __email__ = "suminb@gmail.com"
@@ -109,6 +108,6 @@ def _value(ch):
 def _check_bytes_type(s):
     """Checks if the input is in an appropriate type."""
 
-    if not isinstance(s, bytes):
+    if (not isinstance(s, bytes)) and (not isinstance(s, bytearray)):
         msg = "expected bytes-like object, not %s" % s.__class__.__name__
         raise TypeError(msg)

--- a/ksuid/base62.py
+++ b/ksuid/base62.py
@@ -1,0 +1,114 @@
+# -*- coding: utf-8 -*-
+"""
+base62
+~~~~~~
+
+Originated from http://blog.suminb.com/archives/558
+"""
+
+__title__ = "base62"
+__author__ = "Sumin Byeon"
+__email__ = "suminb@gmail.com"
+__version__ = "0.3.2"
+
+CHARSET = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz"
+BASE = 62
+
+
+def bytes_to_int(s, byteorder="big", signed=False):
+    """Converts a byte array to an integer value.
+
+    Python 3 comes with a built-in function to do this, but we would like to
+    keep our code Python 2 compatible.
+    """
+
+    try:
+        return int.from_bytes(s, byteorder, signed=signed)
+    except AttributeError:
+        # For Python 2.x
+        if byteorder != "big" or signed:
+            raise NotImplementedError()
+
+        # NOTE: This won't work if a generator is given
+        n = len(s)
+        ds = (x << (8 * (n - 1 - i)) for i, x in enumerate(bytearray(s)))
+
+        return sum(ds)
+
+
+def encode(n, minlen=1):
+    """Encodes a given integer ``n``."""
+
+    chs = []
+    while n > 0:
+        r = n % BASE
+        n //= BASE
+
+        chs.append(CHARSET[r])
+
+    if len(chs) > 0:
+        chs.reverse()
+    else:
+        chs.append("0")
+
+    s = "".join(chs)
+    s = CHARSET[0] * max(minlen - len(s), 0) + s
+    return s
+
+
+def encodebytes(s):
+    """Encodes a bytestring into a base62 string.
+
+    :param s: A byte array
+    """
+
+    _check_bytes_type(s)
+    return encode(bytes_to_int(s))
+
+
+def decode(b):
+    """Decodes a base62 encoded value ``b``."""
+
+    if b.startswith("0z"):
+        b = b[2:]
+
+    l, i, v = len(b), 0, 0
+    for x in b:
+        v += _value(x) * (BASE ** (l - (i + 1)))
+        i += 1
+
+    return v
+
+
+def decodebytes(s):
+    """Decodes a string of base62 data into a bytes object.
+
+    :param s: A string to be decoded in base62
+    :rtype: bytes
+    """
+
+    decoded = decode(s)
+    buf = bytearray()
+    while decoded > 0:
+        buf.append(decoded & 0xff)
+        decoded //= 256
+    buf.reverse()
+
+    return bytes(buf)
+
+
+def _value(ch):
+    """Decodes an individual digit of a base62 encoded string."""
+
+    try:
+        return CHARSET.index(ch)
+    except ValueError:
+        raise ValueError("base62: Invalid character (%s)" % ch)
+
+
+def _check_bytes_type(s):
+    """Checks if the input is in an appropriate type."""
+
+    if not isinstance(s, bytes):
+        msg = "expected bytes-like object, not %s" % s.__class__.__name__
+        raise TypeError(msg)

--- a/ksuid/ksuid.py
+++ b/ksuid/ksuid.py
@@ -1,41 +1,38 @@
 from datetime import date
-import datetime
 import os
 import time
+
+from .base62 import decodebytes, encodebytes
 
 
 # Used instead of zero(January 1, 1970),, so that the lifespan of KSUIDs will be considerably longer
 epochTime = 1400000000
-timeStampLength = 4 # number  bytes storing the timestamp
-bodyLength = 16 # Number of bytes consisting of the UUID
+timeStampLength = 4  # number  bytes storing the timestamp
+bodyLength = 16  # Number of bytes consisting of the UUID
+
 
 class ksuid():
-
     """ The primary classes that encompasses ksuid functionality.
     Does not currently take any arguments on initialization. """
 
     def __init__(self):
-        payload = os.urandom(bodyLength) # generates the payload
+        payload = os.urandom(bodyLength)  # generates the payload
         currTime = int(time.time())
         # Note, this code may throw an overflow exception, far into the future
-        byteEncoding = int(currTime-epochTime).to_bytes(4, byteorder='big')
+        byteEncoding = int(currTime - epochTime).to_bytes(4, byteorder="big")
         self.__uid = list(byteEncoding) + list(payload)
-        
-        
+
     def getDatetime(self):
         """ getDatetime() returns a python date object which represents the approximate time
         that the ksuid was created """
-        
+
         unixTime = self.getTimestamp()
         return date.fromtimestamp(unixTime)
-        
-        
-        
 
     def getTimestamp(self):
         """ Returns the value of the timestamp, as a unix timestamp"""
-        
-        unixTime = int.from_bytes(self.__uid[:timeStampLength], byteorder='big')
+
+        unixTime = int.from_bytes(self.__uid[:timeStampLength], byteorder="big")
         return unixTime + epochTime
 
     # Returns the payload without the unix timestamp
@@ -43,18 +40,39 @@ class ksuid():
         """ Returns the value of the payload, with the timestamp encoded portion removed
         Returns:
              list : An array of integers, that represent the bytes used to encode the UID """
-        
-        return self.__uid[timeStampLength:]
 
+        return self.__uid[timeStampLength:]
 
     def bytes(self):
         """ Returns the UID as raw bytes """
 
         return bytes(self.__uid)
 
+    def toBytes(self):
+        return self.bytes()
+
+    @staticmethod
+    def fromBytes(value):
+        """initializes KSUID from bytes"""
+        if len(value) != timeStampLength + bodyLength:
+            raise Exception("Wrong bytearray length")
+
+        res = ksuid()
+        res.__uid = value
+        return res
+
+    def toBase62(self):
+        """ encodes KSUID with Base62 encoding """
+        return encodebytes(self.bytes())
+
+    @staticmethod
+    def fromBase62(data):
+        """ decodes KSUID from base62 encoding """
+        v = decodebytes(data)
+        return ksuid.fromBytes(v)
+
     def __str__(self):
         """ Creates a string representation of the Ksuid from the  bytelist """
-        
-        hexString = "".join(list(map(lambda x : format(x, "02x"), self.__uid)))
+        hexString = "".join(list(map(lambda x: format(x, "02x"), self.__uid)))
         return hexString
-    
+

--- a/ksuid/ksuid.py
+++ b/ksuid/ksuid.py
@@ -75,4 +75,3 @@ class ksuid():
         """ Creates a string representation of the Ksuid from the  bytelist """
         hexString = "".join(list(map(lambda x: format(x, "02x"), self.__uid)))
         return hexString
-

--- a/ksuid/utils.py
+++ b/ksuid/utils.py
@@ -1,5 +1,5 @@
-
-# sorts a list of ksuids by their date (recent in the front)
-
 def sortKSUID(ksuidList):
+    """
+    sorts a list of ksuids by their date (recent in the front)
+    """
     return sorted(ksuidList, key=lambda x: x.getTimestamp(), reverse=False)

--- a/ksuid/utils.py
+++ b/ksuid/utils.py
@@ -1,5 +1,28 @@
+import codecs
+import sys
+
+
 def sortKSUID(ksuidList):
     """
     sorts a list of ksuids by their date (recent in the front)
     """
     return sorted(ksuidList, key=lambda x: x.getTimestamp(), reverse=False)
+
+
+def int_to_bytes(n, length, byteorder="big"):
+    if sys.version_info[0] >= 3:
+        return int(n).to_bytes(length, byteorder=byteorder)
+
+    h = "%x" % n
+    s = ("0" * (len(h) % 2) + h).zfill(length * 2).decode("hex")
+    return s if byteorder == "big" else s[::-1]
+
+
+def int_from_bytes(s, byteorder="big", signed=False):
+    if sys.version_info[0] >= 3:
+        return int.from_bytes(s, byteorder, signed=signed)
+
+    if isinstance(s, list):
+        s = "".join(s)
+
+    return int(codecs.encode(s, "hex"), 16)

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,7 @@
+flake8==3.3.0
+flake8-import-order==0.12
+flake8-quotes==0.9.0
+pytest==3.1.2
+pytest-mock==1.5.0
+pytest-catchlog==1.2.2
+pytest-cov==2.4.0

--- a/setup.py
+++ b/setup.py
@@ -8,6 +8,6 @@ setup(name="ksuid",
       author="Samuel Resendez",
       author_email="samresendez1@gmail.com",
       license="MIT",
-      packages=['ksuid',],
+      packages=["ksuid"],
       zip_safe=False
       )

--- a/tests/ksuid_test.py
+++ b/tests/ksuid_test.py
@@ -1,45 +1,41 @@
-from ksuid import *
-from utils import *
+import datetime
 import unittest
+
+from ksuid import ksuid
+
+from ksuid.utils import sortKSUID
 
 
 class KSUIDTests(unittest.TestCase):
-
     def setUp(self):
         self.ksList = []
-        for i in range(10000):
+        for i in range(100):
             self.ksList.append(ksuid())
-            
+
         self.ksuid1 = ksuid()
         self.ksuid2 = ksuid()
 
     def testTimeStamp(self):
-        self.assertTrue(self.ksuid1.getTimestamp() <=  self.ksuid2.getTimestamp())
+        self.assertTrue(self.ksuid1.getTimestamp() <= self.ksuid2.getTimestamp())
         self.assertTrue(datetime.datetime.now().day == self.ksuid1.getDatetime().day)
-
 
     def testSort(self):
         self.assertTrue(len(self.ksList) > 0)
         ksList = sortKSUID(self.ksList)
-        for index in range(len(ksList)-1):
-            self.assertTrue(ksList[index].getTimestamp()  >= ksList[index+1].getTimestamp())
 
-
+        for index in range(len(ksList) - 1):
+            self.assertTrue(ksList[index].getTimestamp() >= ksList[index + 1].getTimestamp())
 
     def testStringFunction(self):
         for val in self.ksList:
             self.assertTrue(str(val) == str(val))
-            
-
 
     def testDifferentUIDs(self):
-        for val,index in enumerate(self.ksList):
+        for val, index in enumerate(self.ksList):
             for val2, index2 in enumerate(self.ksList):
                 if index == index2:
                     continue
                 self.assertTrue(str(val2) != str(val))
-
-
 
 
 if __name__ == "__main__":

--- a/tests/ksuid_test.py
+++ b/tests/ksuid_test.py
@@ -9,7 +9,7 @@ from ksuid.utils import sortKSUID
 class KSUIDTests(unittest.TestCase):
     def setUp(self):
         self.ksList = []
-        for i in range(100):
+        for i in range(1000):
             self.ksList.append(ksuid())
 
         self.ksuid1 = ksuid()

--- a/tests/test_ksuid_serialization_support.py
+++ b/tests/test_ksuid_serialization_support.py
@@ -33,3 +33,14 @@ def test_successfully_converts_to_bytes_and_vice_versa():
     uid2 = ksuid.fromBytes(serialized)
     assert str(uid1) == str(uid2)
     assert uid1.bytes() == uid2.bytes()
+
+
+def test_base62_orderable():
+    list = []
+    for _ in range(1000):
+        list.append(ksuid())
+
+    sorted_list = sorted(list, key=lambda x: x.toBase62(), reverse=False)
+
+    for index in range(len(list) - 1):
+        assert sorted_list[index].getTimestamp() >= sorted_list[index + 1].getTimestamp()

--- a/tests/test_ksuid_serialization_support.py
+++ b/tests/test_ksuid_serialization_support.py
@@ -1,4 +1,5 @@
 import string
+import time
 
 from ksuid import ksuid
 
@@ -21,8 +22,10 @@ def test_successfully_converts_to_base62_and_vice_versa():
     serialized = uid1.toBase62()
 
     uid2 = ksuid.fromBase62(serialized)
+
     assert str(uid1) == str(uid2)
     assert uid1.bytes() == uid2.bytes()
+    assert uid1.toBytes() == uid2.toBytes()
     assert uid1.toBase62() == uid2.toBase62()
 
 
@@ -31,8 +34,11 @@ def test_successfully_converts_to_bytes_and_vice_versa():
     serialized = uid1.toBytes()
 
     uid2 = ksuid.fromBytes(serialized)
+
     assert str(uid1) == str(uid2)
     assert uid1.bytes() == uid2.bytes()
+    assert uid1.toBytes() == uid2.toBytes()
+    assert uid1.toBase62() == uid2.toBase62()
 
 
 def test_base62_orderable():
@@ -40,7 +46,64 @@ def test_base62_orderable():
     for _ in range(1000):
         list.append(ksuid())
 
-    sorted_list = sorted(list, key=lambda x: x.toBase62(), reverse=False)
+    sorted_list = sorted(list, key=lambda x: x.toBase62(), reverse=True)
+
+    for index in range(len(list) - 1):
+        assert sorted_list[index].getTimestamp() >= sorted_list[index + 1].getTimestamp()
+
+
+def test_measure_1s_and_compare_ksuids():
+    DELAY_INTERVAL_SECS = 1
+
+    u1 = ksuid()
+    time.sleep(DELAY_INTERVAL_SECS)
+    u2 = ksuid()
+
+    assert u1.toBase62() < u2.toBase62()
+
+    assert u2.getTimestamp() > u1.getTimestamp()
+    assert (u2.getTimestamp() - u1.getTimestamp()) >= 1
+
+    d2 = u2.getDatetime()
+    d1 = u1.getDatetime()
+    assert d2 > d1
+    assert (d2 - d1).total_seconds() >= 1
+
+    assert u1.getPayload() != u2.getPayload()
+
+
+def test_integration_test():
+    uid1 = ksuid()
+    bu = uid1.toBytes()
+
+    assert bu is not None
+
+    uid2 = ksuid.fromBytes(bu)
+
+    assert str(uid1) == str(uid2)
+    assert uid1.bytes() == uid2.bytes()
+    assert uid1.toBytes() == uid2.toBytes()
+    assert uid1.toBase62() == uid2.toBase62()
+
+    b62 = uid1.toBase62()
+    uid3 = ksuid.fromBase62(b62)
+
+    assert str(uid1) == str(uid3)
+    assert uid1.bytes() == uid2.bytes()
+    assert uid1.toBytes() == uid3.toBytes()
+    assert uid1.toBase62() == uid3.toBase62()
+
+    bs = uid1.bytes()
+    assert bs is not None
+
+
+def test_bulk_test_for_base62_with_delays():
+    list = []
+    for _ in range(100):
+        list.append(ksuid())
+        time.sleep(0.01)
+
+    sorted_list = sorted(list, key=lambda x: x.toBase62(), reverse=True)
 
     for index in range(len(list) - 1):
         assert sorted_list[index].getTimestamp() >= sorted_list[index + 1].getTimestamp()

--- a/tests/test_ksuid_serialization_support.py
+++ b/tests/test_ksuid_serialization_support.py
@@ -1,0 +1,37 @@
+import string
+
+from ksuid import ksuid
+
+
+def test_converts_to_base62_and_returns_value_with_numbers_and_letters():
+    valid_symbols = string.digits + string.ascii_letters
+
+    uid = ksuid()
+    value = uid.toBase62()
+
+    assert value is not None
+    assert len(value) > 0
+
+    for v in value:
+        assert v in valid_symbols
+
+
+def test_successfully_converts_to_base62_and_vice_versa():
+    uid1 = ksuid()
+    serialized = uid1.toBase62()
+
+    uid2 = ksuid.fromBase62(serialized)
+    assert str(uid1) == str(uid2)
+    assert uid1.bytes() == uid2.bytes()
+    assert uid1.toBase62() == uid2.toBase62()
+
+
+def test_successfully_converts_to_bytes_and_vice_versa():
+    uid1 = ksuid()
+    serialized = uid1.toBytes()
+
+    uid2 = ksuid.fromBytes(serialized)
+    assert str(uid1) == str(uid2)
+    assert uid1.bytes() == uid2.bytes()
+
+

--- a/tests/test_ksuid_serialization_support.py
+++ b/tests/test_ksuid_serialization_support.py
@@ -33,5 +33,3 @@ def test_successfully_converts_to_bytes_and_vice_versa():
     uid2 = ksuid.fromBytes(serialized)
     assert str(uid1) == str(uid2)
     assert uid1.bytes() == uid2.bytes()
-
-


### PR DESCRIPTION
- adds ability to work in **Python 2**;
- adds **base62** serialization support;
- fixes issues with getDatetime(): now returns timestamp, not just date;
- adds more tests (based on pytest);
- improves PEP8 support;
- Makefile for development (with rules for testing, testing with coverage, etc);
- adds support of serialization to bytes and vice versa.